### PR TITLE
Bug fix: Logout issue after data fetching

### DIFF
--- a/components/Navigation.jsx
+++ b/components/Navigation.jsx
@@ -18,7 +18,7 @@ const Navigation = state => {
 
   const handleClick = () => {
     logOutUser();
-    Router.push('/auth/login');
+    window.location.href = '/auth/login';
   };
 
   return (

--- a/components/Navigation.jsx
+++ b/components/Navigation.jsx
@@ -9,10 +9,10 @@ import { logOutUser } from '../redux/actions/authActions';
 
 const dummyUser = {
   image: 'https://milan.serverlessdays.io/speakers/guillermo-rauch.jpg',
-  name: 'Guillermo Rauch',
+  name: 'Guillermo Rauch'
 };
 
-const Navigation = (state) => {
+const Navigation = state => {
   const { logOutUser, authReducer } = state;
   const userInfo = jwt.decode(authReducer.token);
 
@@ -45,9 +45,8 @@ const Navigation = (state) => {
               userId: 'abc123',
               user: userInfo.username,
               jobTitle: 'Web Developer',
-              src:
-                '',
-            },
+              src: ''
+            }
           }}
         >
           <div>
@@ -67,12 +66,12 @@ const Navigation = (state) => {
             <a className="desktop">Explore</a>
           </div>
         </Link>
-        <Link href="/settings">
+        {/* <Link href="/settings">
           <div>
             <Icon type="setting" className="icon" />
             <a className="desktop">Settings</a>
           </div>
-        </Link>
+        </Link> */}
 
         <div onClick={handleClick}>
           <Icon type="logout" className="icon" />
@@ -174,6 +173,6 @@ const Links = styled.div`
 `;
 
 export default connect(
-  (state) => state,
-  { logOutUser },
+  state => state,
+  { logOutUser }
 )(Navigation);

--- a/lib/withReduxStore.js
+++ b/lib/withReduxStore.js
@@ -7,7 +7,7 @@ import rootReducer from '../redux/reducers/index';
 const makeConfiguredStore = (reducer, initialState) => createStore(
   reducer,
   initialState,
-  composeWithDevTools(applyMiddleware(thunk)),
+  composeWithDevTools(applyMiddleware(thunk))
 );
 
 export const makeStore = (initialState, { isServer }) => {
@@ -25,6 +25,7 @@ export const makeStore = (initialState, { isServer }) => {
   const persistConfig = {
     key: 'nextjs',
     storage,
+    blacklist: ['userReducer']
   };
 
   const persistedReducer = persistReducer(persistConfig, rootReducer);

--- a/pages/auth/login.js
+++ b/pages/auth/login.js
@@ -1,7 +1,7 @@
-// import nookies from 'nookies';
-// import jwt from 'jsonwebtoken';
+import nookies from 'nookies';
+import jwt from 'jsonwebtoken';
 import Login from '../../components/auth/Login';
-// import redirect from '../../lib/redirect';
+import redirect from '../../lib/redirect';
 
 function Page() {
   return (
@@ -12,19 +12,19 @@ function Page() {
 }
 
 // Redirects user to dashboard if they are already logged in
-// Page.getInitialProps = ctx => {
-//   const cookies = nookies.get(ctx);
-//   let validToken = false;
+Page.getInitialProps = ctx => {
+  const cookies = nookies.get(ctx);
+  let validToken = false;
 
-//   if (cookies.token) {
-//     const { exp } = jwt.decode(cookies.token);
-//     validToken = exp > Math.floor(Date.now() / 1000);
-//   }
+  if (cookies.token) {
+    const { exp } = jwt.decode(cookies.token);
+    validToken = exp > Math.floor(Date.now() / 1000);
+  }
 
-//   if (validToken) {
-//     redirect(ctx, '/');
-//   }
-//   return {};
-// };
+  if (validToken) {
+    redirect(ctx, '/');
+  }
+  return {};
+};
 
 export default Page;

--- a/redux/actions/authActions.js
+++ b/redux/actions/authActions.js
@@ -8,18 +8,18 @@ import axiosWithToken from '../axios';
 const _BASE_URL = 'https://niyon-dev.herokuapp.com/api';
 
 const startLoading = () => ({
-  type: types.START_LOADING,
+  type: types.START_LOADING
 });
 
 const stopLoading = () => ({ type: types.STOP_LOADING });
 
 // Action Creator for Social Media Signup
-export const linkedinSignup = () => (dispatch) => {
+export const linkedinSignup = () => dispatch => {
   dispatch(startLoading());
   // console.log('Linkedin endpoint request');
   dispatch(stopLoading());
 };
-export const githubSignup = () => (dispatch) => {
+export const githubSignup = () => dispatch => {
   dispatch(startLoading());
   // console.log('Github endpoint request');
   // axiosWithToken()
@@ -34,21 +34,21 @@ export const githubSignup = () => (dispatch) => {
   // dispatch(stopLoading());
 };
 
-export const facebookSignup = () => (dispatch) => {
+export const facebookSignup = () => dispatch => {
   dispatch(startLoading());
 
   // console.log('Facebook endpoint request');
   dispatch(stopLoading());
 };
 
-export const twitterSignup = () => (dispatch) => {
+export const twitterSignup = () => dispatch => {
   dispatch(startLoading());
 
   // console.log('Twitter endpoint request');
   dispatch(stopLoading());
 };
 
-export const emailSignUp = () => (dispatch) => {
+export const emailSignUp = () => dispatch => {
   dispatch(startLoading());
 
   // console.log('Email endpoint request', userData);
@@ -56,11 +56,11 @@ export const emailSignUp = () => (dispatch) => {
 };
 
 // Action creator for persisting location data
-export const locationData = (data) => (dispatch) => {
+export const locationData = data => dispatch => {
   dispatch({ type: types.START_LOADING });
   return axios
     .post(`${_BASE_URL}/location/getLocation`, data)
-    .then((res) => {
+    .then(res => {
       dispatch({ type: types.SET_LOCATION_DATA, payload: res.data.data });
       return res.data.status;
     })
@@ -70,44 +70,44 @@ export const locationData = (data) => (dispatch) => {
 };
 
 // Action creator for persisting profile data
-export const profileData = (data) => ({
+export const profileData = data => ({
   type: types.SET_PROFILE_DATA,
-  payload: data,
+  payload: data
 });
 
-export const socialData = (data) => {
+export const socialData = data => {
   Router.push('/auth/location');
   return {
     type: types.SET_USER_NAME,
-    payload: data,
+    payload: data
   };
 };
 
 // Action Creator for Singup a user with email
 // body {username, email, password}
-export const emailSignup = (data) => (dispatch) => {
+export const emailSignup = data => dispatch => {
   dispatch({ type: types.REGISTER_USER_REQUEST });
   // console.log('SignUp data: ', data);
   return axios
     .post(`${_BASE_URL}/user/signup`, data)
-    .then((res) => {
+    .then(res => {
       dispatch({
         type: types.SET_EMAIL_DATA,
         payload: {
           token: res.data.data.token,
-          data: res.data.data.user,
-        },
+          data: res.data.data.user
+        }
       });
       nookies.set({}, 'token', res.data.data.token, {
-        maxAge: 60 * 60 * 24 * 30,
-        path: '/',
+        maxAge: 60 * 60 * 24 * 14,
+        path: '/'
       });
       return res.data.status;
     })
-    .catch((err) => {
+    .catch(err => {
       dispatch({
         type: types.REGISTER_USER_FAILURE,
-        payload: err.response.data.message,
+        payload: err.response.data.message
       });
 
       return err.response.data.message;
@@ -119,11 +119,11 @@ export const emailSignup = (data) => (dispatch) => {
 // data: {locationId: String, industryId: String}
 // username
 // status - data that will persist in redux-resist store
-export const userTypeHandler = (data, username, type, status) => (dispatch) => {
+export const userTypeHandler = (data, username, type, status) => dispatch => {
   dispatch({ type: types.START_LOADING });
   return axiosWithToken()
     .post(`${_BASE_URL}/${type}/${username}/${type}`, data)
-    .then((res) => {
+    .then(res => {
       dispatch({ type: types.SET_USER_TYPE, payload: status });
       return res.data.status;
     })
@@ -134,11 +134,11 @@ export const userTypeHandler = (data, username, type, status) => (dispatch) => {
 
 // Action Creator for getting Location Data from the Server based on the City
 // data: city:String  => City and Country
-export const locationRequest = (data) => (dispatch) => {
+export const locationRequest = data => dispatch => {
   dispatch({ type: types.START_LOADING });
   return axios
     .get(`${_BASE_URL}/autocomplete/${data}`)
-    .then((res) => {
+    .then(res => {
       dispatch({ type: types.STOP_LOADING });
       return res.data.data;
     })
@@ -148,10 +148,10 @@ export const locationRequest = (data) => (dispatch) => {
 };
 
 // Action Creator for getting all the jobs type from database
-export const getJobTitles = () => (dispatch) => {
+export const getJobTitles = () => dispatch => {
   axios
     .get(`${_BASE_URL}/jobs/all`)
-    .then((res) => {
+    .then(res => {
       dispatch({ type: types.GET_ALL_JOBS, payload: res.data.data });
     })
     .catch(() => {});
@@ -160,19 +160,19 @@ export const getJobTitles = () => (dispatch) => {
 // Action Creator for updating/patch user information gather from the steps
 // data: {firstName: String, lastName: String, country: String, city: String, bio: String}
 // user : username
-export const userProfileInfo = (data, user) => (dispatch) => {
+export const userProfileInfo = (data, user) => dispatch => {
   dispatch({ type: types.USER_INFO_REQUEST });
   return axiosWithToken()
     .patch(`${_BASE_URL}/user/${user}/profile`, data)
-    .then((res) => {
+    .then(res => {
       dispatch({ type: types.USER_INFO_SUCCESS, payload: res.data });
       // return status code in case of success
       return res.data.status;
     })
-    .catch((err) => {
+    .catch(err => {
       dispatch({
         type: types.USER_INFO_FAIL,
-        payload: err.response.data.message,
+        payload: err.response.data.message
       });
       return err.response.status;
     });
@@ -181,7 +181,7 @@ export const userProfileInfo = (data, user) => (dispatch) => {
 // Action Creator for upload user image to cloudinary API
 // data: image in FormatData object
 // user : username
-export const imageUpload = (data, user) => (dispatch) => {
+export const imageUpload = (data, user) => dispatch => {
   dispatch(startLoading());
   axiosWithToken()
     .patch(`${_BASE_URL}/user/${user}/image/upload`, data)
@@ -195,11 +195,11 @@ export const imageUpload = (data, user) => (dispatch) => {
 
 // Action Creator for adding social media handlers
 // data: {user_id:integer, facebook: String, linkedin: String, twitter: String}
-export const socialDataHandler = (data, username) => (dispatch) => {
+export const socialDataHandler = (data, username) => dispatch => {
   dispatch({ type: types.START_LOADING });
   return axiosWithToken()
     .post(`${_BASE_URL}/user/${username}/socialmedia`, data)
-    .then((res) => {
+    .then(res => {
       dispatch({ type: types.SET_SOCIAL_MEDIA_DATA, payload: data });
       return res.data.status;
     })
@@ -208,75 +208,75 @@ export const socialDataHandler = (data, username) => (dispatch) => {
     });
 };
 
-export const logInUser = ({ email, password }) => (dispatch) => {
+export const logInUser = ({ email, password }) => dispatch => {
   dispatch({ type: types.LOG_IN_USER_REQUEST });
   return axios
     .post(`${_BASE_URL}/user/login`, { email, password })
-    .then((res) => {
+    .then(res => {
       dispatch({
         type: types.LOG_IN_USER_SUCCESS,
         payload: {
           token: res.data.data.token,
-          message: res.data.data.message,
-        },
+          message: res.data.data.message
+        }
       });
       nookies.set({}, 'token', res.data.data.token, {
-        maxAge: 60 * 60 * 24 * 30,
-        path: '/',
+        maxAge: 60 * 60 * 24 * 14,
+        path: '/'
       });
       return res.data.status;
     })
-    .catch((error) => {
+    .catch(error => {
       dispatch({
         type: types.LOG_IN_USER_FAILURE,
-        payload: error.message,
+        payload: error.message
       });
       return error.response.data.message;
     });
 };
 
-export const logOutUser = () => (dispatch) => {
+export const logOutUser = () => dispatch => {
   dispatch({ type: types.LOG_OUT_USER });
   nookies.destroy({}, 'token', { path: '/' });
 };
 
-export const resetPassword = (props) => (dispatch) => {
+export const resetPassword = props => dispatch => {
   dispatch({ type: types.RESET_PASSWORD_REQUEST });
   return axios
     .post(`${_BASE_URL}/user/resetpassword`, { email: props.email })
-    .then((res) => {
+    .then(res => {
       dispatch({
         type: types.RESET_PASSWORD_SUCCESS,
-        payload: res.data.data.message,
+        payload: res.data.data.message
       });
       Router.push('/auth/email-sent');
     })
-    .catch((error) => {
+    .catch(error => {
       dispatch({
         type: types.RESET_PASSWORD_FAILURE,
-        payload: error.response.data.message,
+        payload: error.response.data.message
       });
       return error.response.data.message;
     });
 };
 
-export const changePassword = (props) => (dispatch) => {
+export const changePassword = props => dispatch => {
   dispatch({ type: types.CHANGE_PASSWORD_REQUEST });
   axios
     .patch(`${_BASE_URL}/user/newpassword?token=${props.token}`, {
-      password: props.password,
+      password: props.password
     })
-    .then((res) => {
+    .then(res => {
       dispatch({
         type: types.CHANGE_PASSWORD_SUCCESS,
-        payload: res.data.data.message,
+        payload: res.data.data.message
       });
       Router.push('/auth/login');
     })
-    .catch((error) => {
+    .catch(error => {
       dispatch({
         type: types.CHANGE_PASSWORD_FAILURE,
-        payload: error.message,
+        payload: error.message
       });
     });
 };


### PR DESCRIPTION
The logout functionality stopped working after data fetching was implemented, Router.push() uses client side navigation and the props that relied on data from API threw errors because data was no longer fetching on logout. To prevent this, a page refresh was added to force server side navigation which meant the login page was able to render without errors coming from the protected pages. 

Refreshing also ensures the cookie is completely removed from local storage.

Other logout related fixes in this PR:
- [x] Updated the cookie lifespan to 14 days
- [x] Added cookie check to login page to redirect the user to home if already logged in
- [x] Blacklisted userReducer from redux-persist so state will disappear on refresh. 


- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas